### PR TITLE
ランダム出題画面のヘッダーを模擬試験出題画面と統一

### DIFF
--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -4,7 +4,7 @@
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-3">
         <div class="p-2 bg-blue-100 rounded-lg text-blue-600" aria-hidden="true">
-          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" role="img" aria-label="ランダム問題">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"></path>
           </svg>
         </div>


### PR DESCRIPTION
## 概要
ランダム出題画面のヘッダーデザインを、模擬試験画面と統一されたレイアウトに変更しました。

## 主な変更点

### 1. デザインの統一
* 模擬試験画面と同様に、左側にアイコンとタイトルを配置するレイアウトに変更しました。
* アイコンにはランダム出題のメタファーである「フラスコ」を採用し、テーマカラーの **Blue** を適用しました。

## 確認方法
1. ランダム出題を開始してください。
2. 画面上部のヘッダーに青いフラスコアイコンが表示されていることを確認してください。
3. 右側に問題の「カテゴリ名」がタグ風のデザインで表示されていることを確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the question display page with a new header section featuring a left-aligned title area and a right-aligned category badge, improving visual organization and making category information more easily accessible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->