### PR TITLE
ナビゲーションをパーシャル化し、解説画面の上下に配置

### DIFF
--- a/app/views/questions/_navigation.html.erb
+++ b/app/views/questions/_navigation.html.erb
@@ -1,0 +1,11 @@
+<div class="flex flex-col sm:flex-row gap-4 pt-4 border-t border-slate-200">
+  <%= link_to root_path, class: "flex-1 inline-flex justify-center items-center px-6 py-3 border border-slate-300 shadow-sm text-base font-bold rounded-xl text-slate-700 bg-white hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-500 transition-all" do %>
+    <svg class="w-5 h-5 mr-2 -ml-1 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path></svg>
+    トップへ戻る
+  <% end %>
+
+  <%= link_to random_questions_path, class: "flex-1 inline-flex justify-center items-center px-6 py-3 border border-transparent shadow-sm text-base font-bold rounded-xl text-white bg-indigo-600 hover:bg-indigo-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-600 transition-all" do %>
+    <span>次の問題へ</span>
+    <svg class="w-5 h-5 ml-2 -mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path></svg>
+  <% end %>
+</div>

--- a/app/views/questions/solution.html.erb
+++ b/app/views/questions/solution.html.erb
@@ -1,29 +1,25 @@
 <div class="min-h-screen bg-slate-50 py-12 px-4 sm:px-6">
   <div class="max-w-3xl mx-auto space-y-8">
-
+    
     <%= render "shared/result_status", is_correct: @is_correct %>
 
-    <%= render "shared/terminal_display",
-        content: @question.content,
-        label: "Question.php (Review)" %>
+    <div class="pb-4">
+      <%= render "navigation" %>
+    </div>
 
-    <%= render "shared/choices_feedback",
-        question: @question,
-        user_choice_ids: @user_answer_ids %>
+    <%= render "shared/terminal_display", 
+        content: @question.content,
+        label: "Question.php (Review)" 
+    %>
+
+    <%= render "shared/choices_feedback", 
+        question: @question, 
+        user_choice_ids: @user_answer_ids 
+    %>
 
     <%= render "shared/reference_info", question: @question %>
 
-    <div class="flex flex-col sm:flex-row gap-4 pt-4 border-t border-slate-200">
-      <%= link_to root_path, class: "flex-1 inline-flex justify-center items-center px-6 py-3 border border-slate-300 shadow-sm text-base font-bold rounded-xl text-slate-700 bg-white hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-slate-500 transition-all" do %>
-        <svg class="w-5 h-5 mr-2 -ml-1 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path></svg>
-        トップへ戻る
-      <% end %>
-
-      <%= link_to random_questions_path, class: "flex-1 inline-flex justify-center items-center px-6 py-3 border border-transparent shadow-sm text-base font-bold rounded-xl text-white bg-indigo-600 hover:bg-indigo-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-600 transition-all" do %>
-        <span>次の問題へ</span>
-        <svg class="w-5 h-5 ml-2 -mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path></svg>
-      <% end %>
-    </div>
+    <%= render "navigation" %>
 
   </div>
 </div>


### PR DESCRIPTION
## 概要
現在、ランダム出題の解説画面において、「次の問題へ」等のナビゲーションボタンが画面最下部にしか存在しません。
解説が長い場合や、解説を読む必要がない正解時などに、ユーザーがスクロールを強いられるUX課題を解消するため、画面上部にもナビゲーションを配置しました。

## 主な変更点

### 1. ナビゲーションのコンポーネント化
* **`app/views/questions/_navigation.html.erb`** (新規作成)
    * 既存のナビゲーションボタン群（トップへ戻る / 次の問題へ）を切り出したパーシャルを作成しました。
    * ランダム出題機能固有のパーツであるため、`questions` 配下に配置しています。

### 2. 解説画面のレイアウト変更
* **`app/views/questions/solution.html.erb`**
    * 作成した `_navigation` パーシャルを、画面下部だけでなく画面上部（結果ステータスバナーの直下）にも配置しました。

## 期待される効果
* ユーザーがスクロールすることなく、即座に次の問題へ遷移できるようになり、学習のテンポが向上します。

## 確認方法
1. ランダム出題を開始し、回答してください。
2. 解説画面（結果画面）が表示された際、画面上部（正誤表示のすぐ下）にも「次の問題へ」ボタンが表示されていることを確認してください。
3. 上部のボタンを押下して、正しく次の問題へ遷移できることを確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repositioned navigation controls to the top of the question view for improved accessibility
  * Enhanced navigation layout with responsive design and refined styling for action buttons

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->