### PR TITLE
チェックページのデザインを刷新

### DIFF
--- a/app/views/exams/check.html.erb
+++ b/app/views/exams/check.html.erb
@@ -32,7 +32,7 @@
       </div>
 
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <%= button_to exam_path(@active_exam), method: :get, class: "w-full sm:w-auto min-w-[200px] group inline-flex items-center justify-center px-8 py-4 bg-indigo-600 border border-transparent rounded-xl font-bold text-white text-lg hover:bg-indigo-700 hover:shadow-lg hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-600 transition-all" do %>
+        <%= link_to exam_path(@active_exam), class: "w-full sm:w-auto min-w-[200px] group inline-flex items-center justify-center px-8 py-4 bg-indigo-600 border border-transparent rounded-xl font-bold text-white text-lg hover:bg-indigo-700 hover:shadow-lg hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-600 transition-all" do %>
           <span>続きから再開</span>
           <svg class="w-5 h-5 ml-2 -mr-1 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
         <% end %>


### PR DESCRIPTION
## 概要
未完了の模擬試験がある場合に表示される確認画面（`exams/check`）のデザインを刷新しました。
旧デザインで課題だった「表示が小さすぎる（余白が多すぎる）」点や「ボタン配置のズレ」を解消したUIに変更しました。

## 主な変更点

### 1. レイアウトの刷新 (`exams/check.html.erb`)
* **センターレイアウト**: 全要素を中央揃えにし、重要なメッセージ（再開確認）に視線が集まるようにしました。

### 2. コンテンツの視認性向上
* **日時情報の強調**: 開始日時を強調するための専用エリア（グレーボックス）を設け、情報密度を高めました。
* **ボタンの改善**: 「続きから再開」「破棄して新規開始」ボタンのサイズを大きくし、クリックしやすくしました。

## 影響範囲
* `app/views/exams/check.html.erb`

## 確認方法
1. 模擬試験を開始し、完了せずにトップページ等へ戻ってください。
2. 再度「模擬試験を受験する」をクリックしてください。
3. 確認画面が中央に大きく表示され、レイアウト崩れや余白の違和感がないことを確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned the unfinished-exam UI into a modern, centered card layout with decorative background and improved visual hierarchy
  * Added a "Last Session Started" section showing the exam start time in a localized format
  * Replaced inline links with prominent action buttons: "続きから再開" (resume) and "破棄して新規開始" (discard and start new) with confirmation and improved hover/focus states

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->