### PR TITLE
未完了試験確認画面の再開リンク先を修正

### DIFF
--- a/app/views/exams/check.html.erb
+++ b/app/views/exams/check.html.erb
@@ -32,7 +32,7 @@
       </div>
 
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <%= link_to exam_path(@active_exam), class: "w-full sm:w-auto min-w-[200px] group inline-flex items-center justify-center px-8 py-4 bg-indigo-600 border border-transparent rounded-xl font-bold text-white text-lg hover:bg-indigo-700 hover:shadow-lg hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-600 transition-all" do %>
+        <%= link_to review_exam_path(@active_exam), class: "w-full sm:w-auto min-w-[200px] group inline-flex items-center justify-center px-8 py-4 bg-indigo-600 border border-transparent rounded-xl font-bold text-white text-lg hover:bg-indigo-700 hover:shadow-lg hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-600 transition-all" do %>
           <span>続きから再開</span>
           <svg class="w-5 h-5 ml-2 -mr-1 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
         <% end %>


### PR DESCRIPTION
## 概要
未完了の模擬試験がある場合に表示される確認画面（`exams/check`）において、「続きから再開」ボタンの遷移先が誤っていたため修正しました。

## 変更点
* **リンク先の変更**:
    * 修正後: **`review_exam_path(@active_exam)`** （確認ページへ遷移する）

## 確認方法
1. 模擬試験を中断する。
2. 再度「模擬試験を受験する」を選択し、確認画面を表示する。
3. 「続きから再開」ボタンをクリックし、エラーにならずに確認ページ（Review画面）へ正しく遷移することを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the "continue from where you left off" exam link to navigate to the correct destination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->