### PR TITLE
アクションボタンを上下に追加

### DIFF
--- a/app/views/exams/_index_navigation.html.erb
+++ b/app/views/exams/_index_navigation.html.erb
@@ -1,0 +1,15 @@
+<div class="flex flex-col sm:flex-row justify-center gap-4">
+  <%= link_to root_path, class: "px-6 py-3 bg-white border border-slate-200 text-slate-600 font-bold rounded-xl hover:bg-slate-50 hover:border-slate-300 transition-all shadow-sm flex items-center justify-center" do %>
+    <svg class="w-5 h-5 mr-2 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path>
+    </svg>
+    ダッシュボードへ
+  <% end %>
+
+  <%= link_to check_exams_path, class: "px-6 py-3 bg-indigo-600 text-white font-bold rounded-xl hover:bg-indigo-700 hover:shadow-lg hover:-translate-y-0.5 transition-all shadow-md flex items-center justify-center" do %>
+    <span>新しい模擬試験を受ける</span>
+    <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+    </svg>
+  <% end %>
+</div>

--- a/app/views/exams/index.html.erb
+++ b/app/views/exams/index.html.erb
@@ -9,9 +9,18 @@
     </div>
 
     <% if @exams.any? %>
+      <div class="mb-6">
+        <%= render "index_navigation" %>
+      </div>
+
       <div class="space-y-4">
         <%= render partial: "history_card", collection: @exams, as: :exam %>
       </div>
+
+      <div class="mt-8 pt-8 border-t border-slate-200">
+        <%= render "index_navigation" %>
+      </div>
+
     <% else %>
       <div class="text-center py-12 bg-white rounded-xl shadow-sm border border-slate-100">
         <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-50 mb-4">


### PR DESCRIPTION
## 概要
模擬試験の履歴一覧画面（`exams/index`）において、次のアクションへの導線が不足していたため、リストの上下に「ダッシュボードへ戻る」ボタンと「新しい模擬試験を受ける」ボタンを追加しました。

## 確認方法
1. 模擬試験の履歴一覧画面（`/exams`）を開いてください。
2. 履歴リストの上部および下部にナビゲーションボタンが表示されていることを確認してください。
3. 各ボタンをクリックし、ダッシュボードおよび新規試験開始画面へ正しく遷移することを確認してください。

@coderabbitai
各種出力は日本語でお願いします

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive navigation bar to the exams page with quick-access buttons for returning to the dashboard and starting a new mock exam. Navigation is displayed at both the top and bottom of the exam list for improved accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->