### PR TITLE
カテゴリ編集行の保存/キャンセルボタンをアイコン化

### DIFF
--- a/app/views/admin/categories/_inline_form.html.erb
+++ b/app/views/admin/categories/_inline_form.html.erb
@@ -15,18 +15,28 @@
 
       <div></div>
 
-      <div class="flex items-center gap-4 justify-end">
+      <div class="flex items-center gap-2 justify-end">
         <%= f.number_field :weight, class: "border border-slate-300 rounded p-1 w-16 text-right text-sm", min: 0, max: 100, step: 0.1 %>
         <span class="text-sm text-slate-600 pr-2">%</span>
       </div>
 
-      <div class="flex items-center gap-3 justify-center">
-        <%= f.submit "保存", class: "text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 px-2 py-1 rounded cursor-pointer" %>
+      <div class="flex items-center gap-2 justify-center">
+        <%= button_tag type: "submit", class: "text-white bg-blue-600 hover:bg-blue-700 p-2 rounded-lg cursor-pointer transition-colors shadow-sm", title: "保存" do %>
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+          </svg>
+        <% end %>
 
-        <%= link_to "キャンセル", render_row_admin_category_path(category),
+        <%= link_to render_row_admin_category_path(category),
             data: { turbo_frame: dom_id(category) },
-            class: "text-sm font-medium border border-red-400 text-red-600 hover:bg-red-50 hover:text-red-700 py-1 rounded transition-colors" %>
+            class: "text-slate-400 hover:text-red-600 hover:bg-red-50 p-2 rounded-lg transition-colors",
+            title: "キャンセル" do %>
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+          </svg>
+        <% end %>
       </div>
+
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
## 概要
管理画面のカテゴリー編集行において、「キャンセル」ボタンの文字数によるレイアウト崩れが発生していたため、ボタンデザインを刷新しました。
テキストボタンを「アイコンボタン」に変更することで、省スペース化と表示崩れの解消を行いました。

## 主な変更点
* **`app/views/admin/categories/_form_row.html.erb`**
    * **保存**: テキストボタンから `Check` アイコンボタンに変更。
    * **キャンセル**: テキストリンクから `X` アイコンリンクに変更。

## 理由
「キャンセル」という5文字の幅が狭いカラム内で改行を引き起こしていたため、アイコン化によってスペースを確保し、レイアウトを安定させるため。

## 確認方法
1. 管理画面のカテゴリー一覧（`/admin/categories`）を開いてください。
2. 任意のカテゴリーの「編集」ボタンを押し、インライン編集モードにしてください。
3. 保存（✔）とキャンセル（✖）のボタンがアイコンで表示され、レイアウトが崩れていないことを確認してください。
4. それぞれのボタンが正常に機能する（保存される、または編集モードが解除される）ことを確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved admin form controls with enhanced spacing, updated button styling, and added visual icons for save and cancel actions, providing clearer visual feedback to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->