### PR TITLE
LPメインコピーの行間調整

### DIFF
--- a/app/views/home/_hero_content.html.erb
+++ b/app/views/home/_hero_content.html.erb
@@ -1,6 +1,6 @@
 <div class="w-full lg:w-1/2 flex flex-col items-start text-left">
 
-  <h1 class="text-4xl lg:text-6xl font-extrabold text-slate-900 leading-[1.1] tracking-tight mb-6">
+  <h1 class="text-4xl lg:text-6xl font-extrabold text-slate-900 leading-[1.25] tracking-tight mb-6">
     最短距離で掴む、<br>
     <span class="text-blue-600">初級認定試験</span>の合格。
   </h1>


### PR DESCRIPTION
### 変更の概要

ランディングページ（LP）のメインコピー「最短距離で掴む、初級認定試験の合格。」について、日本語の可読性向上のため、行間を調整しました。

### 目的

現在の設定（`leading-[1.1]`）では文字が視覚的に詰まりすぎていたため、これを適切な値に修正することで、タイトルの勢いを保ちつつ、読みやすさを改善します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * 見出しのテキスト行間隔を調整し、視覚的なバランスを改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->