### PR TITLE
鍵に関する設定を追記

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -35,6 +35,7 @@ env:
     DB_HOST: 133.125.53.173
 ssh:
   user: ubuntu
+  keys: ["~/.ssh/github_ssh"]
   # Specify the registry server, if you're not using Docker Hub
   # server: registry.digitalocean.com / ghcr.io / ...
   # username: my-user


### PR DESCRIPTION
### 概要
鍵が見つからずデプロイが失敗していたので、設定ファイルに場所を明示しました。