### PR TITLE
スマホ表示時の問題回答画面ナビゲーション配置修正

### DIFF
--- a/app/views/exam_questions/show.html.erb
+++ b/app/views/exam_questions/show.html.erb
@@ -33,15 +33,14 @@
         guard_answer: true %>
 
     <nav class="pt-8 border-t border-slate-200 grid grid-cols-2 sm:grid-cols-3 gap-4" aria-label="問題移動">
-
       <% prev_q = @exam_question.previous_question %>
       <% if prev_q %>
-        <%= link_to exam_exam_question_path(@exam, prev_q), class: "flex items-center justify-center px-4 py-3 text-sm font-bold text-slate-600 bg-white border border-slate-300 rounded-xl hover:bg-slate-50 transition-colors" do %>
+        <%= link_to exam_exam_question_path(@exam, prev_q), class: "col-span-2 sm:col-span-1 flex items-center justify-center px-4 py-3 text-sm font-bold text-slate-600 bg-white border border-slate-300 rounded-xl hover:bg-slate-50 transition-colors" do %>
           <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path></svg>
           前へ
         <% end %>
       <% else %>
-        <div class="invisible" aria-hidden="true"></div>
+        <div class="hidden sm:block sm:invisible" aria-hidden="true"></div>
       <% end %>
 
       <%= link_to review_exam_path(@exam), class: "flex items-center justify-center px-4 py-3 text-sm font-bold text-slate-600 bg-slate-100 rounded-xl hover:bg-slate-200 transition-colors" do %>


### PR DESCRIPTION
験問題回答画面において、スマートフォン表示時のナビゲーションボタンの配置を変更しました。

### 修正前
<img width="423" height="729" alt="image" src="https://github.com/user-attachments/assets/12c8cab8-8e7f-49b8-955f-e539a6a514d4" />

### 修正後
<img width="423" height="729" alt="image" src="https://github.com/user-attachments/assets/fded755e-cd55-431c-8cb9-8f10b9817d6e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * 試験問題ナビゲーションバーのレスポンシブデザインが改善されました。小型画面とタブレット、デスクトップなど異なる画面サイズでのレイアウト表示が最適化され、すべてのデバイスでより適切に機能するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->