### PR TITLE
終了した試験問題に対する回答と閲覧を禁止に

### DIFF
--- a/app/controllers/exam_questions_controller.rb
+++ b/app/controllers/exam_questions_controller.rb
@@ -3,6 +3,7 @@
 class ExamQuestionsController < ApplicationController
   before_action :set_exam
   before_action :set_exam_question
+  before_action :ensure_exam_in_progress, only: %i[show answer]
 
   def show
   end
@@ -38,6 +39,10 @@ class ExamQuestionsController < ApplicationController
       @exam_question = @exam.exam_questions.find(params[:id])
     rescue ActiveRecord::RecordNotFound
       redirect_to root_path, alert: "指定された試験または問題は見つかりませんでした。"
+    end
+
+    def ensure_exam_in_progress
+      raise ActiveRecord::RecordNotFound if @exam.completed_at
     end
 
     def answer_params


### PR DESCRIPTION
### 概要
終了した試験問題に対して直接URLを打ち込むとアクセスできてしまい、解答しなおせるというバグを修正しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 完了済みテストへの予期しないアクセスを防止するようになりました。テスト完了後、そのテストへアクセスしようとするとエラーが返されます。これにより、テストの完全性が保証されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->