### PR TITLE
模擬試験結果ページのナビゲーションボタン表示不具合の修正

### DIFF
--- a/app/javascript/controllers/result_reveal_controller.js
+++ b/app/javascript/controllers/result_reveal_controller.js
@@ -139,7 +139,7 @@ export default class extends Controller {
     setTimeout(() => {
       if (this.hasActionButtonsTarget) {
         this.actionButtonsTargets.forEach((el) => {
-          el.classList.remove("opacity-0", "translate-y-4");
+          el.classList.remove("opacity-0", "translate-y-full");
         });
       }
     }, stagger * 2);


### PR DESCRIPTION
## 概要
模擬試験結果ページのアニメーション完了後に、下部ナビゲーションボタンが表示されない問題を修正しました。

## 変更点
- `result_reveal_controller.js`
  - `showNextElements`メソッド内で削除するクラスを`translate-y-4`からHTMLの実装に合わせた`translate-y-full`に変更しました。
  - これにより初期設定の非表示クラスが正しく除去され、スライドインアニメーションが動作するようになります。

## 動作確認
1. 模擬試験結果ページを開く
2. スコア表示のアニメーション完了後、画面下部からナビゲーションボタンがスライドインして表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * アクションボタンのアニメーション終了効果を改善しました。オフセット値を調整し、より滑らかで視覚的に一貫したトランジション表現を実現します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->