### PR TITLE
includesしてた箇所を明示的にpreloadするように変更

### DIFF
--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -4,7 +4,7 @@ class Admin::QuestionsController < AdminController
   before_action :set_question, only: [:edit, :update, :destroy]
 
   def index
-    @questions = Question.includes(:category).active.order(created_at: :desc)
+    @questions = Question.preload(:category).active.order(created_at: :desc)
   end
 
   def new

--- a/spec/models/exam/question_selector_spec.rb
+++ b/spec/models/exam/question_selector_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Exam::QuestionSelector, type: :model do
         result_ids = selector.call
 
         questions_map = Question.where(id: result_ids)
-                                .includes(:category)
+                                .preload(:category)
                                 .index_by(&:id)
 
         result_chapters = result_ids.map { |id| questions_map[id].category.chapter_number }


### PR DESCRIPTION
### 概要
コントローラーの各所で`includes`が使われていましたが、SQLが見えずらくなる副作用があるので今のうちに明示的に取得方法を宣言するように変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 内部的なデータ取得方法の改善を実施しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->