### PR TITLE
litestreamをダウングレード

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y libvips libyaml-0-2 curl ca-certificates && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.5/litestream-0.5.5-linux-x86_64.tar.gz /tmp/litestream.tar.gz
+ADD https://github.com/benbjohnson/litestream/releases/download/v0.5.2/litestream-0.5.2-linux-x86_64.tar.gz /tmp/litestream.tar.gz
 RUN tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz && \
     rm /tmp/litestream.tar.gz
 


### PR DESCRIPTION
### 概要
litestreamを0.5.2にダウングレードした

### 理由
https://github.com/benbjohnson/litestream/issues/912
こちらのIssueで言われているように

> The root cause was AWS SDK Go v2 v1.73.0+ introduced automatic checksum calculation using aws-chunked encoding with trailing checksums, which R2 and many other S3-compatible providers don't support.

自動チェックサム計算が導入されたことで、R2に対するアップロードがうまくいかなくなったためです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チューニング**
  * Docker イメージ内の依存関係バージョンを調整しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->