### PR TITLE
cloudflareのIPをtrusted_proxiesに追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,4 +67,30 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  cloudflare_ips = %w[
+    103.21.244.0/22
+    103.22.200.0/22
+    103.31.4.0/22
+    104.16.0.0/13
+    104.24.0.0/14
+    108.162.192.0/18
+    131.0.72.0/22
+    141.101.64.0/18
+    162.158.0.0/15
+    172.64.0.0/13
+    173.245.48.0/20
+    188.114.96.0/20
+    190.93.240.0/20
+    197.234.240.0/22
+    198.41.128.0/17
+    2400:cb00::/32
+    2606:4700::/32
+    2803:f800::/32
+    2405:b500::/32
+    2405:8100::/32
+    2a06:98c0::/29
+    2c0f:f248::/32
+  ]
+
+  config.action_dispatch.trusted_proxies = cloudflare_ips.map { |ip| IPAddr.new(ip) }
 end


### PR DESCRIPTION
### 概要
Cloudflareを導入した

### 変更点
Cloudflareを導入するに当たり、CloudflareのIPをホワイトリストに登録し、アクセス元のIPがわかるようにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 本番環境のプロキシ設定を更新しました。信頼できるプロキシとして新たなIPレンジを追加し、ヘルスチェックエンドポイントの処理を改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->