### PR TITLE
使われていなかったボタンのデザインを削除

### DIFF
--- a/app/components/common/button/component.rb
+++ b/app/components/common/button/component.rb
@@ -6,7 +6,6 @@ module Common
       VARIANTS = {
         primary: "bg-indigo-600 text-white hover:bg-indigo-700 shadow-md border-transparent focus:ring-indigo-500",
         secondary: "bg-white text-slate-600 border-slate-200 hover:bg-slate-50 hover:border-slate-300 shadow-sm border focus:ring-slate-200",
-        danger: "bg-rose-600 text-white hover:bg-rose-700 shadow-md border-transparent focus:ring-rose-500",
         ghost: "bg-transparent text-slate-600 hover:bg-slate-100 hover:text-slate-900 border-transparent focus:ring-slate-200"
       }.freeze
 

--- a/spec/components/common/button/component_spec.rb
+++ b/spec/components/common/button/component_spec.rb
@@ -33,12 +33,6 @@ RSpec.describe Common::Button::Component, type: :component do
       expect(page).to have_css(".bg-white.text-slate-600.border-slate-200")
     end
 
-    it "dangerスタイルが適用されること" do
-      render_inline(described_class.new(variant: :danger)) { "削除" }
-      expect(page).to have_css(".bg-rose-600")
-      expect(page).to have_css(".focus\\:ring-rose-500")
-    end
-
     it "ghostスタイルが適用されること" do
       render_inline(described_class.new(variant: :ghost)) { "閉じる" }
       expect(page).to have_css(".bg-transparent.text-slate-600")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * ボタンコンポーネントから危険アクション用のスタイルバリアント(danger)を削除しました。該当するスタイル定義と関連する設定も削除されています。現在このバリアントを使用している場合は、他のバリアントへの置き換えが必要となります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->