### PR TITLE
提出ページのリファクタリング

### DIFF
--- a/app/views/exams/reviews/show.html.erb
+++ b/app/views/exams/reviews/show.html.erb
@@ -1,7 +1,7 @@
 <% title "回答状況確認" %>
 <% noindex %>
 
-<main class="bg-slate-50 pb-32 font-sans">
+<main class="flex-1 bg-slate-50 pb-16 font-sans">
 
   <%= render Exams::Review::Header::Component.new(exam: @exam) %>
 
@@ -30,8 +30,7 @@
     </ul>
   </div>
 
-  <footer class="fixed bottom-0 left-0 right-0 bg-white border-t border-slate-200 p-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] z-40">
-    <div class="max-w-xl mx-auto">
+    <div class="max-w-xl mx-auto mt-8">
       <%= form_with url: exam_submission_path(@exam), method: :post, data: { turbo_confirm: "本当に提出しますか？提出後は変更できません。" } do %>
         <%= render Common::Button::Component.new(
           type: :submit,
@@ -44,5 +43,4 @@
         <% end %>
       <% end %>
     </div>
-  </footer>
 </main>


### PR DESCRIPTION
レビューページの背景が見切れていたので、表示領域の拡張を行いつつボタン配置領域を変更した

### 変更前
<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/58006d74-28c7-4ae9-8d11-f85a1a736daf" />

### 変更後
<img width="1679" height="962" alt="image" src="https://github.com/user-attachments/assets/f28cbb28-8094-438f-883e-c4d8d0cb4e41" />
