### PR TITLE
assume_sslを有効化

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,6 +32,8 @@ Rails.application.configure do
 
   config.action_view.preload_links_header = false
 
+  config.assume_ssl = true
+
   cloudflare_ips = %w[
     103.21.244.0/22
     103.22.200.0/22


### PR DESCRIPTION
## 概要
本番環境において、RailsアプリケーションがSSL配下で動作していることを明示するため、`config.assume_ssl = true` を有効化しました。

## 変更の背景・目的
現在、本番環境において、RailsがリクエストをHTTPとして処理しているため、発行されるセッションCookieに `Secure` 属性が付与されない状態となっています。

## 関連資料
- [Railsガイド: config.assume_ssl](https://railsguides.jp/configuring.html#config-assume-ssl)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ向上**
  * 本番環境でのSSL処理を強化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->