### PR TITLE
選択肢でもマークダウン記法を使えるように調整

### DIFF
--- a/app/components/common/choices/component.html.erb
+++ b/app/components/common/choices/component.html.erb
@@ -14,9 +14,9 @@
       </div>
 
       <div class="ml-4 flex-1">
-        <span class="<%= text_classes %>">
-          <%= choice.content %>
-        </span>
+        <div class="<%= text_classes %>">
+          <%= formatted_content(choice.content) %>
+        </div>
       </div>
 
       <div class="absolute inset-0 rounded-xl border-2 border-indigo-500 opacity-0 peer-checked:opacity-100 pointer-events-none transition-opacity duration-200"></div>

--- a/app/components/common/choices/component.rb
+++ b/app/components/common/choices/component.rb
@@ -3,11 +3,26 @@
 module Common
   module Choices
     class Component < ViewComponent::Base
+      WRAPPER_STYLE = %w[
+        [&_code]:font-mono
+        [&_code]:text-sm
+        [&_code]:text-slate-700
+        [&_code]:bg-slate-100
+        [&_code]:rounded
+        [&_code]:leading-relaxed
+        [&_code]:px-1.5
+        [&_code]:py-0.5
+      ].join(" ").freeze
+
       def initialize(question:, input_name: nil, selected_choice_ids: [], disabled: false)
         @question = question
         @input_name = input_name
         @selected_choice_ids = Array(selected_choice_ids).map(&:to_i)
         @disabled = disabled
+      end
+
+      def formatted_content(content)
+        MarkdownContent.new(content).to_html
       end
 
       private
@@ -21,8 +36,11 @@ module Common
 
         def text_classes
           classes = %w[
-          block text-base text-slate-700 group-hover:text-indigo-900 transition-colors
+            block text-base text-slate-700 group-hover:text-indigo-900 transition-colors
           ]
+
+          classes << WRAPPER_STYLE
+
           classes << "peer-checked:font-bold" unless @disabled
           classes.join(" ")
         end


### PR DESCRIPTION
### 概要
選択肢の視認性を高めるため、インラインコードとして記述するのを目的に選択肢でマークダウン記法が使えるように変更した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 選択肢のコンテンツ表示にマークダウンフォーマッティング機能を追加しました。

* **Style**
  * 選択肢の表示要素を改善し、スタイリングの一貫性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->